### PR TITLE
address directory

### DIFF
--- a/get-kernel
+++ b/get-kernel
@@ -45,7 +45,7 @@ my $version_id = make_version_id($kernel_version);
 
 my(@paths) = uniqstr(($detail =~ m{
         <a\s+href="(
-                        (?:$arch/|)
+                        (?:$arch/)?
                         linux-[\w-]+ # package name
                         -(?:\Q$version_id\E)
                         (?:-generic)? # build variant (none and "generic")

--- a/get-kernel
+++ b/get-kernel
@@ -45,6 +45,7 @@ my $version_id = make_version_id($kernel_version);
 
 my(@paths) = uniqstr(($detail =~ m{
         <a\s+href="(
+                        (?:$arch/|)
                         linux-[\w-]+ # package name
                         -(?:\Q$version_id\E)
                         (?:-generic)? # build variant (none and "generic")
@@ -60,3 +61,4 @@ foreach my $path(@paths) {
 }
 
 say "Done. Try `sudo dpkg -i *.deb && sudo update-grub && sudo reboot`";
+


### PR DESCRIPTION
I addressed directory structure. 
From [v5.7.2](https://kernel.ubuntu.com/~kernel-ppa/mainline/v5.7.2/), .deb files seem to exist under the arch (amd64, ....) directory.
For example, `v5.7.2/amd64/linux-headers-5.7.2-050702-generic_5.7.2-050702.202006101934_amd64.deb `.